### PR TITLE
Handle vaultx.HTTPError as a known error without wrapping it

### DIFF
--- a/tests/integration/test_approle.py
+++ b/tests/integration/test_approle.py
@@ -27,7 +27,7 @@ class TestApprole(VaultxIntegrationTestCase, TestCase):
             param(
                 "no secret ids",
                 num_secrets_to_create=0,
-                raises=exceptions.VaultxError,
+                raises=exceptions.HTTPError,
             ),
             param(
                 "one secret id",

--- a/vaultx/exceptions.py
+++ b/vaultx/exceptions.py
@@ -110,6 +110,8 @@ def handle_unknown_exception(  # noqa: C901
     def wrapper(*args: tp.Any, **kwargs: tp.Any) -> tp.Any:
         try:
             return obj(*args, **kwargs)
+        except HTTPError:
+            raise
         except VaultxError:
             raise
         except Exception as exc:


### PR DESCRIPTION
Check out: #108 
Policy changed: `vaultx.HTTPError` shouldn't be wrapped.